### PR TITLE
Only cast ProjectileSource to an Entity if it is one. Fixes cast errors ...

### DIFF
--- a/src/net/aufdemrand/sentry/SentryListener.java
+++ b/src/net/aufdemrand/sentry/SentryListener.java
@@ -11,7 +11,9 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
+
 
 
 import net.citizensnpcs.api.CitizensAPI;
@@ -166,7 +168,10 @@ public class SentryListener implements Listener {
 		Entity entto = event.getEntity();
 
 		if(	entfrom  instanceof org.bukkit.entity.Projectile && entfrom instanceof Entity){
-			entfrom = (Entity) ((org.bukkit.entity.Projectile) entfrom).getShooter();
+			ProjectileSource source = ((Projectile) entfrom).getShooter();
+			if (source instanceof Entity){
+				entfrom = (Entity) ((org.bukkit.entity.Projectile) entfrom).getShooter();
+			}
 		}
 
 		SentryInstance from = plugin.getSentry(entfrom);


### PR DESCRIPTION
...due to change in CB #2998 (see BUKKIT-1156 + BUKKIT-1038)

Attempting to cast a ProjectileSource to an Entity will cause an error if it is a non-entity (such as dispenser): http://pastebin.com/eisbswy4
